### PR TITLE
fix(ci): pin AsyncAPI CLI and gate GitHub jobs on changed paths (RMNGGH-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
 name: CI
 
 on:
@@ -31,11 +30,46 @@ env:
   PYTHON_VERSION: "3.12"
 
 jobs:
+  # Single diff computed once and shared via needs:/outputs
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+      python_cdk: ${{ steps.filter.outputs.python_cdk }}
+      dashboard: ${{ steps.filter.outputs.dashboard }}
+      api_docs: ${{ steps.filter.outputs.api_docs }}
+      mqtt: ${{ steps.filter.outputs.mqtt }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Diff against base
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+            echo "python_cdk=true" >> "$GITHUB_OUTPUT"
+            echo "dashboard=true" >> "$GITHUB_OUTPUT"
+            echo "api_docs=true" >> "$GITHUB_OUTPUT"
+            echo "mqtt=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          base="origin/${{ github.base_ref }}"
+          check() { git diff --quiet "$base" -- "$@" && echo false || echo true; }
+          echo "go=$(check '**/*.go' go.mod go.sum go.work go.work.sum Makefile src/esp-cloud-common)" >> "$GITHUB_OUTPUT"
+          echo "python_cdk=$(check '**/*.py' requirements.txt cdk.json Stackfile.yaml deployment/docker/Dockerfile Makefile)" >> "$GITHUB_OUTPUT"
+          echo "dashboard=$(check 'dashboard/**')" >> "$GITHUB_OUTPUT"
+          echo "api_docs=$(check 'docs/api/**')" >> "$GITHUB_OUTPUT"
+          echo "mqtt=$(check docs/api/MQTT_*.yaml docs/api/Push_*.yaml)" >> "$GITHUB_OUTPUT"
+
   # Ginkgo across all three go.work modules. `make test` delegates to each
   # submodule's own `make test` (TEST_SUBMODULES) because ginkgo's package
   # discovery stops at Go module boundaries.
   unittest:
     name: Unit tests
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -61,10 +95,28 @@ jobs:
             build/tests/
           if-no-files-found: ignore
 
+  # Static analysis via the rmng-lint tooling. Non-blocking, same as GitLab's go_lint.
+  go_lint:
+    name: Go lint
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make lint
+
   # govulncheck, scanned per module because it does not cross go.work boundaries.
   # Blocking, same as GitLab's go_vulncheck.
   vulncheck:
     name: govulncheck
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -81,6 +133,8 @@ jobs:
   # dashboard job below covers those.
   cdk_synth:
     name: CDK synth
+    needs: changes
+    if: needs.changes.outputs.python_cdk == 'true'
     runs-on: ubuntu-latest
     env:
       CDK_PUBLISH: "true"
@@ -118,6 +172,8 @@ jobs:
   # reused for the npm ci + build so the build invocation stays in one place.
   dashboard:
     name: Admin dashboard
+    needs: changes
+    if: needs.changes.outputs.dashboard == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -140,6 +196,8 @@ jobs:
   # Schema validation for the published API definitions.
   api_docs:
     name: API definitions
+    needs: changes
+    if: needs.changes.outputs.api_docs == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -151,10 +209,15 @@ jobs:
           npx --yes @apidevtools/swagger-cli validate docs/api/Api_Swagger.yaml
           npx --yes @apidevtools/swagger-cli validate docs/api/User_Api_Swagger.yaml
       - name: Validate AsyncAPI
+        if: needs.changes.outputs.mqtt == 'true'
         run: |
-          npx --yes @asyncapi/cli validate docs/api/MQTT_Node.yaml
-          npx --yes @asyncapi/cli validate docs/api/MQTT_User.yaml
-          npx --yes @asyncapi/cli validate docs/api/Push_User.yaml
+          # npx --yes @asyncapi/cli pulls in @asyncapi/generator@3.4.0, which pins its own dependency @asyncapi/generator-hooks to version 0.1.1 — a version that was never published to npm — so the install fails with ETARGET
+          npm init --yes >/dev/null
+          npm pkg set overrides.@asyncapi/generator-hooks=0.1.0
+          npm install --no-save @asyncapi/cli@6.0.0
+          npx @asyncapi/cli validate docs/api/MQTT_Node.yaml
+          npx @asyncapi/cli validate docs/api/MQTT_User.yaml
+          npx @asyncapi/cli validate docs/api/Push_User.yaml
 
   # Working-tree secret scan, configured by .gitleaks.toml.
   #


### PR DESCRIPTION
- pin @asyncapi/cli to 6.0.0 with a generator-hooks override so validation no longer fails when npm resolves @asyncapi/generator to 3.4.0's unpublished 0.1.1 dependency
- add a shared changed-paths job and gate unittest, go_lint, vulncheck, cdk_synth, dashboard, and api_docs on it: rules so both pipelines skip/run identically per file touched
- add a go_lint job

## Description

<!-- What does this PR do, and why? Link the issue it addresses. -->

Fixes #

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [x] Documentation / CI / chore

## How was this tested?

<!-- Unit tests, integration tests (`make itest`), manual verification. -->

CI itself will test it

## Checklist

- [x] The change is focused — one logical change per PR
- [ ] `make go_build`, `make test`, and `make lint` pass locally
- [ ] I have deployed the change and `make itest` pass
- [ ] Documentation updated where behavior or interfaces changed